### PR TITLE
Fixed build job needs name in Read.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ jobs:
           node-version: 16
       - run: npm ci
       - run: npx semantic-release --dry-run
-        id: get-next-version
+        id: get-next-version 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:


### PR DESCRIPTION
Fixed the GitHub example build needs name.