### PR TITLE
feat: add `new-release-git-tag` output variable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
       new-release-version: ${{ steps.get-next-version.outputs.new-release-version }}
+      new-release-git-tag: ${{ steps.get-next-version.outputs.new-release-git-tag }}
 
   release:
     runs-on: ubuntu-latest
@@ -37,7 +38,7 @@ jobs:
     if: needs.get-next-version.outputs.new-release-published == 'true'
 
     steps:
-      - run: echo "The new release version is ${{ needs.get-next-version.outputs.new-release-version }}"
+      - run: echo "The new release version is ${{ needs.get-next-version.outputs.new-release-version }} with tag ${{ needs.get-next-version.outputs.new-release-git-tag }}"
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ jobs:
     outputs:
       new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
       new-release-version: ${{ steps.get-next-version.outputs.new-release-version }}
+      new-release-git-tag: ${{ steps.get-next-version.outputs.new-release-git-tag }}
 
   build:
     runs-on: ubuntu-latest
@@ -76,6 +77,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: echo "The new release version is ${{ needs.get-next-version.outputs.new-release-version }}"
+      - run: echo "The new release git tag is ${{ needs.get-next-version.outputs.new-release-git-tag }}"
+
 
   release:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: next-version
+    needs: get-next-version
     if: needs.get-next-version.outputs.new-release-published == 'true'
     steps:
       - uses: actions/checkout@v3

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ function verifyConditions() {
 function generateNotes(_pluginConfig, { nextRelease }) {
   core.setOutput("new-release-published", "true");
   core.setOutput("new-release-version", nextRelease.version);
+  core.setOutput("new-release-git-tag", nextRelease.gitTag);
 }
 
 module.exports = {


### PR DESCRIPTION
Adds `new-release-tag` output variable that is the _actual_ value of the `nextRelease.gitTag`.