### PR TITLE
feat: update output delimiter & include `notes` if present

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,7 @@ jobs:
       new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
       new-release-version: ${{ steps.get-next-version.outputs.new-release-version }}
       new-release-git-tag: ${{ steps.get-next-version.outputs.new-release-git-tag }}
+      new-release-notes: ${{ steps.get-next-version.outputs.new-release-notes }}
 
   release:
     runs-on: ubuntu-latest
@@ -39,6 +40,11 @@ jobs:
 
     steps:
       - run: echo "The new release version is ${{ needs.get-next-version.outputs.new-release-version }} with tag ${{ needs.get-next-version.outputs.new-release-git-tag }}"
+      - run: |
+          cat << 'EOF'
+          The release notes are:
+          ${{ needs.get-next-version.outputs.new-release-notes }}
+          EOF
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Currently, the plugin exports the following GitHub Actions's outputs:
 | `new-release-published` | Whether a new release was published. The return value is in the form of a string. (`true` or `false`) |
 | `new-release-version`   | If a new release was published, the version of the new release. (e.g. `1.3.0`)                        |
 | `new-release-git-tag`   | If a new version was published, the git tag of the new release. (e.g. `v1.3.0`)                       |
+| `new-release-notes`     | If a new version was published, the generated notes (if present)                                      |
 
 ### GitHub Actions Example
 

--- a/index.js
+++ b/index.js
@@ -2,11 +2,15 @@
 
 const { env } = require("node:process");
 const { appendFileSync } = require("node:fs");
+const { EOL } = require("node:os");
+const { randomUUID } = require("node:crypto");
 
 function exportData(name, value) {
   console.log(`semantic-release-export-data: ${name}=${value}`);
   if (env.GITHUB_OUTPUT) {
-    const output = `${name}=${value}\n`;
+    // Borrowed from https://github.com/actions/toolkit/blob/ddc5fa4ae84a892bfa8431c353db3cf628f1235d/packages/core/src/file-command.ts#L27  
+    const delimiter = "output_delimiter_".concat(randomUUID());
+    const output = "".concat(name, "<<", delimiter, EOL, value, EOL, delimiter, EOL);
     appendFileSync(env.GITHUB_OUTPUT, output);
   }
 }
@@ -19,6 +23,8 @@ function generateNotes(_pluginConfig, { nextRelease }) {
   exportData("new-release-published", "true");
   exportData("new-release-version", nextRelease.version);
   exportData("new-release-git-tag", nextRelease.gitTag);
+  // Export notes if present
+  nextRelease.notes && exportData("new-release-release-notes", nextRelease.notes);
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function generateNotes(_pluginConfig, { nextRelease }) {
   exportData("new-release-version", nextRelease.version);
   exportData("new-release-git-tag", nextRelease.gitTag);
   // Export notes if present
-  nextRelease.notes && exportData("new-release-release-notes", nextRelease.notes);
+  nextRelease.notes && exportData("new-release-notes", nextRelease.notes);
 }
 
 module.exports = {


### PR DESCRIPTION
Hi @felipecrs , first of all thank you for this plugin. I was looking for a way to preview the release on open PRs, and your plugin helped me with that.

One thing it was missing was `nextRelease.notes`, to easily preview and verify release notes. For that, I applied a patch to your npm module: https://github.com/carloscortonc/rpi-cli/blob/7adf997dade8ed5fe119a15165625002dec2c66b/patches/semantic-release-export-data%2B1.1.1.patch

Just exporting `nextRelease.notes` generated an error, because the content is multi-line (https://github.com/carloscortonc/rpi-cli/actions/runs/18257911158/job/51981820460#step:6:289)
I reviewed how [@actions/core::setOutput](https://github.com/actions/toolkit/blob/ddc5fa4ae84a892bfa8431c353db3cf628f1235d/packages/core/src/file-command.ts#L27) solved it, and is by using a custom delimiter.

### Proposed changes
The proposed changes are:
- Include `nextRelease.notes` in a new output variable `new-release-notes`
- Define custom delimiter so output-setting works with multi-line values

These changes in action can be seen [here](https://github.com/carloscortonc/rpi-cli/pull/19#issuecomment-3369009854) by using [this workflow](https://github.com/carloscortonc/rpi-cli/blob/7adf997dade8ed5fe119a15165625002dec2c66b/.github/workflows/release-base.yml#L50-L58)